### PR TITLE
Patch up Docker Hub builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM archlinux AS fontship-base
+FROM archlinux:20200306 AS fontship-base
 
+RUN sed -i -e '/IgnorePkg *=/s/^.*$/IgnorePkg = coreutils/' /etc/pacman.conf
 # Setup Caleb's hosted Arch repository with prebuilt dependencies
 RUN pacman-key --init && pacman-key --populate
 RUN sed -i  /etc/pacman.conf -e \


### PR DESCRIPTION
Local builds still have been working, but Docker Hub did something to their filesystems that fresh GNU coreutils is very unhappy about. This is a standby until [the upstream issue](https://github.com/archlinux/archlinux-docker/issues/32) is fixed.