### PR TITLE
Install system, Python & module dependencies before build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
           fetch-depth: 0
       - name: Fetch Tags
         run: git fetch --prune --tags
+      - name: Setup system dependencies
+        run: sudo apt-get install sfnt2woff-zopfli ttfautohint zsh
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Setup Python dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
           fetch-depth: 0
       - name: Fetch Tags
         run: git fetch --prune --tags
+      - name: Setup Python
+        uses: actions/setup-python@v2
+      - name: Setup Python dependencies
+        run: pip install -r requirements.txt
       - name: Build
         run: |
           ./bootstrap.sh


### PR DESCRIPTION
I did a bad. I push some stuff to master that Worked For Me™. Why I was tired and grumpy and just did it anyway is a story for another day. This PR is to fix what broke, mainly CI not having the same environment as my local machine and hence failing to build.