### PR TITLE
Punt build operations to existing build scripts

### DIFF
--- a/fontship.in
+++ b/fontship.in
@@ -13,6 +13,7 @@ sys.path.append("@pythondir@/".replace("${prefix}", "@prefix@"))
 
 import click
 import fontship
+import os.path
 import subprocess
 
 @click.group()
@@ -25,8 +26,12 @@ def fontship():
 @click.argument('target', nargs=-1)
 def make(ctx, target):
     """Build specified target(s)."""
-    # TODO: Check if a local Makefile exists first, and run it with an extra include if so
-    process = subprocess.run(['make', '-f', SRCDIR + "rules.mk"] + list(target))
+    args = ['make']
+    args += ['-f', SRCDIR + 'rules.mk']
+    for fname in ['GNUmakefile', 'makefile', 'Makefile']:
+        if os.path.isfile(fname):
+            args += ['-f', fname]
+    process = subprocess.run(args + list(target))
     #, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     process
 


### PR DESCRIPTION
This is for easy migration of repositories to start using Fontship **now** before it starts doing anything fancy my providing a migration path for existing build scripts such that functionality can be swapped out piece by piece.