### PR TITLE
Tidy up the builds process

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -12,6 +12,11 @@ SHELL := zsh
 .ONESHELL:
 .SECONDEXPANSION:
 
+# Don't drop intermediate artifacts (saves rebulid time and aids debugging)
+.SECONDARY:
+.PRECIOUS: %
+.DELETE_ON_ERROR:
+
 CONTAINERIZED != test -f /.dockerenv && echo true || echo false
 
 # Initial environment setup

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -212,7 +212,7 @@ ifeq ($(CANONICAL),ufo)
 
 # UFO normalize
 
-%.ufo: .last-commit
+%.ufo: $(BUILDDIR)/last-commit
 	cat <<- EOF | $(PYTHON)
 		from defcon import Font, Info
 		ufo = Font('$@')
@@ -225,7 +225,7 @@ endif
 
 # UFO -> OTF
 
-%.otf: %.ufo .last-commit
+%.otf: %.ufo $(BUILDDIR)/last-commit
 	cat <<- EOF | $(PYTHON)
 		from ufo2ft import compileOTF
 		from defcon import Font
@@ -237,7 +237,7 @@ endif
 
 # UFO -> TTF
 
-%.ttf: %.ufo .last-commit
+%.ttf: %.ufo $(BUILDDIR)/last-commit
 	cat <<- EOF | $(PYTHON)
 		from ufo2ft import compileTTF
 		from defcon import Font
@@ -252,7 +252,7 @@ endif
 $(BUILDDIR)/%-VF-variable.otf: %.glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -o variable-cff2 --output-path $@
 
-$(VARIABLEOTFS): %.otf: $(BUILDDIR)/%-variable.otf .last-commit
+$(VARIABLEOTFS): %.otf: $(BUILDDIR)/%-variable.otf $(BUILDDIR)/last-commit
 	cp $< $@
 	$(normalizeVersion)
 
@@ -271,7 +271,7 @@ $(BUILDDIR)/%-nomvar.ttx: $(BUILDDIR)/%.ttf
 $(BUILDDIR)/%.ttf: $(BUILDDIR)/%.ttx
 	$(TTX) $(TTXFLAGS) -o $@ $<
 
-$(VARIABLETTFS): %.ttf: $(BUILDDIR)/%-unhinted-nomvar.ttf .last-commit
+$(VARIABLETTFS): %.ttf: $(BUILDDIR)/%-unhinted-nomvar.ttf $(BUILDDIR)/last-commit
 	cp $< $@
 	$(normalizeVersion)
 
@@ -280,7 +280,7 @@ $(VARIABLETTFS): %.ttf: $(BUILDDIR)/%-unhinted-nomvar.ttf .last-commit
 $(BUILDDIR)/$(FontBase)-%-instance.otf: $(FontBase).glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o otf --output-path $@
 
-$(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf .last-commit
+$(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
 	cp $< $@
 	$(normalizeVersion)
 
@@ -290,7 +290,7 @@ $(BUILDDIR)/$(FontBase)-%-instance.ttf: $(FontBase).glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o ttf --output-path $@
 	$(GFTOOLS) fix-dsig --autofix $@
 
-$(STATICTTFS): %.ttf: $(BUILDDIR)/%-instance.ttf .last-commit
+$(STATICTTFS): %.ttf: $(BUILDDIR)/%-instance.ttf $(BUILDDIR)/last-commit
 	$(TTFAUTOHINT) $(TTFAUTOHINTFLAGS) -n $< $@
 	$(normalizeVersion)
 
@@ -304,8 +304,8 @@ $(STATICTTFS): %.ttf: $(BUILDDIR)/%-instance.ttf .last-commit
 
 # Utility stuff
 
-.PHONY: .last-commit
-.last-commit:
+.PHONY: $(BUILDDIR)/last-commit
+$(BUILDDIR)/last-commit: | $(BUILDDIR)
 	git update-index --refresh --ignore-submodules ||:
 	git diff-index --quiet --cached HEAD -- *.ufo
 	ts=$$(git log -n1 --pretty=format:%cI HEAD)

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -72,17 +72,18 @@ VARIABLETTFS = $(addsuffix -VF.ttf,$(FontBase))
 VARIABLEWOFFS = $(addsuffix -VF.woff,$(FontBase))
 VARIABLEWOFF2S = $(addsuffix -VF.woff2,$(FontBase))
 
+_FONTMAKEFLAGS = --master-dir '{tmp}' --instance-dir '{tmp}'
 ifeq ($(DEBUG)),true)
-FONTMAKEFLAGS = --verbose INFO
+FONTMAKEFLAGS ?= $(_FONTMAKEFLAGS) --verbose INFO
 TTXFLAGS = -v
 TTFAUTOHINTFLAGS = -v --debug
 else
 ifeq ($(VERBOSE)),true)
-FONTMAKEFLAGS = --verbose WARNING
+FONTMAKEFLAGS ?= $(_FONTMAKEFLAGS) --verbose WARNING
 TTXFLAGS = -v
 TTFAUTOHINTFLAGS = -v
 else
-FONTMAKEFLAGS ?= --verbose ERROR
+FONTMAKEFLAGS ?= $(_FONTMAKEFLAGS) --verbose ERROR
 TTXFLAGS ?=
 TTFAUTOHINTFLAGS ?=
 endif
@@ -219,11 +220,11 @@ endif
 	$(normalizeVersion)
 
 variable_ttf/%-VF.ttf: %.glyphs
-	$(FONTMAKE) $(FONTMAKEFLAGS) --master-dir '{tmp}' -g $< -o variable
+	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -o variable
 	$(GFTOOLS) fix-dsig --autofix $@
 
 variable_otf/%-VF.otf: %.glyphs
-	$(FONTMAKE) $(FONTMAKEFLAGS) --master-dir '{tmp}' -g $< -o variable-cff2
+	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -o variable-cff2
 
 %.ttf: variable_ttf/%.ttf .last-commit
 	$(GFTOOLS) fix-nonhinting $< $@
@@ -237,14 +238,14 @@ variable_otf/%-VF.otf: %.glyphs
 	$(normalizeVersion)
 
 instance_otf/$(FontBase)-%.otf: $(FontBase).glyphs
-	$(FONTMAKE) $(FONTMAKEFLAGS) --master-dir '{tmp}' -g $< -i "$(FamilyName) $*" -o otf
+	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o otf
 
 %.otf: instance_otf/%.otf .last-commit
 	cp $< $@
 	$(normalizeVersion)
 
 instance_ttf/$(FontBase)-%.ttf: $(FontBase).glyphs
-	$(FONTMAKE) $(FONTMAKEFLAGS) --master-dir '{tmp}' -g $< -i "$(FamilyName) $*" -o ttf
+	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o ttf
 	$(GFTOOLS) fix-dsig --autofix $@
 
 %.ttf: instance_ttf/%.ttf .last-commit


### PR DESCRIPTION
This mostly just tidies up the files so that intermediate things designers should not be concerned with in most cases are in a hidden build directory.

Functionally it also allows building groups of fonts by either output format (ttf, otf, etc.) or by type (static, variable).