### PR TITLE
chore: Drop fancy Docker entry point hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,7 @@ FROM fontship-base AS fontship
 LABEL maintainer="Caleb Maclennan <caleb@alerque.com>"
 LABEL version="$VCS_REF"
 
-COPY build-aux/docker-entrypoint.sh /usr/local/bin
-
 COPY --from=fontship-builder /pkgdir /
 
 WORKDIR /data
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["fontship"]

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ dist_data_DATA = src/rules.mk src/functions.mk
 CLEANFILES = $(bin_SCRIPTS)
 
 .PHONY: docker
-docker: Dockerfile build-aux/docker-entrypoint.sh
+docker: Dockerfile
 	docker build \
 		--build-arg VCS_REF="$(VERSION)" \
 		--tag theleagueof/fontship:HEAD \

--- a/build-aux/docker-entrypoint.sh
+++ b/build-aux/docker-entrypoint.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-set -e
-
-if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || [ "${1}" == "make" ]; then
-  set -- fontship "$@"
-fi
-
-exec "$@"


### PR DESCRIPTION
This 'hack' is useful in a few rare cases, but also causes a lot of
problems (e.g. Can't run `fontship -q make` without it eating
arguments). The most useful thing is getting a bash shell in the
container, but that can actually be done with a docker command line
argument too. Best just to force our CLI unless the user is very
specific about doing otherwise — least surprise.