### PR TITLE
Allow multiple family names per project

### DIFF
--- a/fontship.in
+++ b/fontship.in
@@ -38,10 +38,10 @@ def cli(debug, quiet, verbose):
 def make(ctx, target):
     """Build specified target(s)."""
     args = ['make']
-    args += ['-f', SRCDIR + 'rules.mk']
     for fname in ['GNUmakefile', 'makefile', 'Makefile', 'rules.mk']:
         if os.path.isfile(fname):
             args += ['-f', fname]
+    args += ['-f', SRCDIR + 'rules.mk']
     for flag in flags:
         if flags[flag]:
             args += [ flag + "=true" ]

--- a/src/functions.mk
+++ b/src/functions.mk
@@ -1,7 +1,9 @@
-glyphInstances = $(shell $(PYTHON) -c 'from glyphsLib import GSFont; list(map(lambda x: print(x.name), GSFont("$1").instances))')
-glyphsFamilyName = $(shell $(PYTHON) -c 'from glyphsLib import GSFont; print(GSFont("$1").familyName)')
-ufoInstances = $(shell $(PYTHON) -c 'import babelfont; print(babelfont.OpenFont("$1").info.styleName)')
-ufoFamilyName = $(shell $(PYTHON) -c 'import babelfont; print(babelfont.OpenFont("$1").info.familyName)')
+glyphsFamilyNames ?= $(shell $(PYTHON) -c 'from glyphsLib import GSFont; print(GSFont("$1").familyName.title().replace(" ", ""))')
+sfdFamilyNames ?=
+ufoFamilyNames ?= $(shell $(PYTHON) -c 'import babelfont; print(babelfont.OpenFont("$1").info.familyName.title().replace(" ", ""))')
+glyphsInstances ?= $(shell $(PYTHON) -c 'from glyphsLib import GSFont; list(map(lambda x: print(x.name), GSFont("$1").instances))')
+ufoInstances ?= $(shell $(PYTHON) -c 'import babelfont; print(babelfont.OpenFont("$1").info.styleName)')
+sfdInstances ?=
 
 define normalizeVersion =
 	$(FONTV) $(FONTVFLAGS) write --ver=$(FontVersion) $(if $(isTagged),--rel,--dev --sha1) $@

--- a/src/functions.mk
+++ b/src/functions.mk
@@ -5,6 +5,6 @@ glyphsInstances ?= $(shell $(PYTHON) -c 'from glyphsLib import GSFont; list(map(
 ufoInstances ?= $(shell $(PYTHON) -c 'import babelfont; print(babelfont.OpenFont("$1").info.styleName)')
 sfdInstances ?=
 
-define normalizeVersion =
+define normalizeVersion ?=
 	$(FONTV) $(FONTVFLAGS) write --ver=$(FontVersion) $(if $(isTagged),--rel,--dev --sha1) $@
 endef

--- a/src/rules-glyphs.mk
+++ b/src/rules-glyphs.mk
@@ -42,26 +42,16 @@ $(VARIABLETTFS): %.ttf: $(BUILDDIR)/%-variable-hinted.ttf.fix $(BUILDDIR)/last-c
 
 # Glyphs -> Static OTF
 
-$(BUILDDIR)/$(FontBase)-%-instance.otf: $(SOURCEDIR)/$(FontBase).glyphs | $(BUILDDIR)
-	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o otf --output-path $@
-	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig -f $@
-
-$(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
-	cp $< $@
-	$(normalizeVersion)
+define otf_instance_template ?=
+$$(BUILDDIR)/$1-%-instance.otf: $1.glyphs | $$(BUILDDIR)
+	$$(FONTMAKE) $$(FONTMAKEFLAGS) -g $$< -i "$1 $$*" -o otf --output-path $$@
+	$$(GFTOOLS) $$(GFTOOLSFLAGS) fix-dsig -f $$@
+endef
 
 # Glyphs -> Static TTF
 
-$(BUILDDIR)/$(FontBase)-%-instance.ttf: $(SOURCEDIR)/$(FontBase).glyphs | $(BUILDDIR)
-	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o ttf --output-path $@
-	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig -f $@
-
-$(BUILDDIR)/%-hinted.ttf: $(BUILDDIR)/%-instance.ttf
-	$(TTFAUTOHINT) $(TTFAUTOHINTFLAGS) -n $< $@
-
-$(BUILDDIR)/%-hinted.ttf.fix: $(BUILDDIR)/%-hinted.ttf
-	$(GFTOOLS) $(GFTOOLSFLAGS) fix-hinting $<
-
-$(STATICTTFS): %.ttf: $(BUILDDIR)/%-hinted.ttf.fix $(BUILDDIR)/last-commit
-	cp $< $@
-	$(normalizeVersion)
+define ttf_instance_template ?=
+$$(BUILDDIR)/$1-%-instance.ttf: $1.glyphs | $$(BUILDDIR)
+	$$(FONTMAKE) $$(FONTMAKEFLAGS) -g $$< -i "$1 $$*" -o ttf --output-path $$@
+	$$(GFTOOLS) $$(GFTOOLSFLAGS) fix-dsig -f $$@
+endef

--- a/src/rules-glyphs.mk
+++ b/src/rules-glyphs.mk
@@ -11,7 +11,7 @@ FONTMAKEFLAGS += --master-dir '{tmp}' --instance-dir '{tmp}'
 
 # Glyphs -> Varibale OTF
 
-$(BUILDDIR)/%-VF-variable.otf: %.glyphs | $(BUILDDIR)
+$(BUILDDIR)/%-VF-variable.otf: $(SOURCEDIR)/%.glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -o variable-cff2 --output-path $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-vf-meta $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-unwanted-tables --tables MVAR $@ ||:
@@ -23,7 +23,7 @@ $(VARIABLEOTFS): %.otf: $(BUILDDIR)/%-variable.otf $(BUILDDIR)/last-commit
 
 # Glyphs -> Varibale TTF
 
-$(BUILDDIR)/%-VF-variable.ttf: %.glyphs | $(BUILDDIR)
+$(BUILDDIR)/%-VF-variable.ttf: $(SOURCEDIR)/%.glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -o variable --output-path $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-vf-meta $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-unwanted-tables --tables MVAR $@ ||:
@@ -42,7 +42,7 @@ $(VARIABLETTFS): %.ttf: $(BUILDDIR)/%-variable-hinted.ttf.fix $(BUILDDIR)/last-c
 
 # Glyphs -> Static OTF
 
-$(BUILDDIR)/$(FontBase)-%-instance.otf: $(FontBase).glyphs | $(BUILDDIR)
+$(BUILDDIR)/$(FontBase)-%-instance.otf: $(SOURCEDIR)/$(FontBase).glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o otf --output-path $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig -f $@
 
@@ -52,7 +52,7 @@ $(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
 
 # Glyphs -> Static TTF
 
-$(BUILDDIR)/$(FontBase)-%-instance.ttf: $(FontBase).glyphs | $(BUILDDIR)
+$(BUILDDIR)/$(FontBase)-%-instance.ttf: $(SOURCEDIR)/$(FontBase).glyphs | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -g $< -i "$(FamilyName) $*" -o ttf --output-path $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig -f $@
 

--- a/src/rules-sfd.mk
+++ b/src/rules-sfd.mk
@@ -1,2 +1,0 @@
-%.sfd: %.ufo
-	echo SDF: $@

--- a/src/rules-ufo.mk
+++ b/src/rules-ufo.mk
@@ -9,19 +9,15 @@
 
 # UFO -> OTF
 
-$(BUILDDIR)/%-instance.otf: $(SOURCEDIR)/%.ufo | $(BUILDDIR)
-	$(FONTMAKE) $(FONTMAKEFLAGS) -u $< -o otf --output-path $@
-
-$(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
-	cp $< $@
-	$(normalizeVersion)
+define otf_instance_template ?=
+$$(BUILDDIR)/$1-%-instance.otf: $1-%.ufo | $$(BUILDDIR)
+	$$(FONTMAKE) $$(FONTMAKEFLAGS) -u $$< -o otf --output-path $$@
+endef
 
 # UFO -> TTF
 
-$(BUILDDIR)/%-instance.ttf: $(SOURCEDIR)/%.ufo | $(BUILDDIR)
-	$(FONTMAKE) $(FONTMAKEFLAGS) -u $< -o ttf --output-path $@
-	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig --autofix $@
-
-$(STATICTTFS): %.ttf: $(BUILDDIR)/%-instance.ttf $(BUILDDIR)/last-commit
-	$(TTFAUTOHINT) $(TTFAUTOHINTFLAGS) -n $< $@
-	$(normalizeVersion)
+define ttf_instance_template ?=
+$$(BUILDDIR)/$1-%-instance.ttf: $1-%.ufo | $$(BUILDDIR)
+	$$(FONTMAKE) $$(FONTMAKEFLAGS) -u $$< -o ttf --output-path $$@
+	$$(GFTOOLS) $$(GFTOOLSFLAGS) fix-dsig --autofix $$@
+endef

--- a/src/rules-ufo.mk
+++ b/src/rules-ufo.mk
@@ -9,7 +9,7 @@
 
 # UFO -> OTF
 
-$(BUILDDIR)/%-instance.otf: %.ufo | $(BUILDDIR)
+$(BUILDDIR)/%-instance.otf: $(SOURCEDIR)/%.ufo | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -u $< -o otf --output-path $@
 
 $(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
@@ -18,7 +18,7 @@ $(STATICOTFS): %.otf: $(BUILDDIR)/%-instance.otf $(BUILDDIR)/last-commit
 
 # UFO -> TTF
 
-$(BUILDDIR)/%-instance.ttf: %.ufo | $(BUILDDIR)
+$(BUILDDIR)/%-instance.ttf: $(SOURCEDIR)/%.ufo | $(BUILDDIR)
 	$(FONTMAKE) $(FONTMAKEFLAGS) -u $< -o ttf --output-path $@
 	$(GFTOOLS) $(GFTOOLSFLAGS) fix-dsig --autofix $@
 

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -29,7 +29,9 @@ PUBDIR ?= $(PROJECTDIR)/pub
 # Some Makefile shinanigans to avoid aggressive trimming
 space := $() $()
 
-CANONICAL ?= $(shell git ls-files | grep -q '\.glyphs$'' && echo glyphs || echo ufo)
+CANONICAL ?= $(or $(shell git ls-files | grep -q '\.glyphs$$' && echo glyphs),\
+			      $(shell git ls-files | grep -q '\.sfd$$' && echo sfd),\
+			      $(shell git ls-files | grep -q '\.ufo$$' && echo ufo))
 
 # Allow overriding executables used
 FONTMAKE ?= fontmake

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -26,6 +26,8 @@ PROJECT ?= $(shell $(CONTAINERIZED) || $(PYTHON) $(PYTHONFLAGS) -c 'print("$(GIT
 _PROJECTDIR != cd "$(shell dirname $(firstword $(MAKEFILE_LIST)))/" && pwd
 PROJECTDIR ?= $(_PROJECTDIR)
 PUBDIR ?= $(PROJECTDIR)/pub
+SOURCEDIR ?= sources
+
 # Some Makefile shinanigans to avoid aggressive trimming
 space := $() $()
 
@@ -57,12 +59,12 @@ include $(FONTSHIPDIR)/functions.mk
 
 # Read font name from metadata file or guess from repository name
 ifeq ($(CANONICAL),glyphs)
-FamilyName ?= $(call glyphsFamilyName,$(firstword $(wildcard *.glyphs)))
+FamilyName ?= $(call glyphsFamilyName,$(firstword $(wildcard $(SOURCEDIR)/*.glyphs)))
 isVariable ?= true
 endif
 
 ifeq ($(CANONICAL),ufo)
-FamilyName ?= $(call ufoFamilyName,$(firstword $(wildcard *.ufo)))
+FamilyName ?= $(call ufoFamilyName,$(firstword $(wildcard $(SOURCEDIR)/*.ufo)))
 endif
 
 FamilyName ?= $(shell $(CONTAINERIZED) || $(PYTHON) $(PYTHONFLAGS) -c 'print("$(PROJECT)".replace("-", " ").title())')
@@ -84,9 +86,9 @@ endif
 # Look for what fonts & styles are in this repository that will need building
 FontBase = $(subst $(space),,$(FamilyName))
 
-# FontStyles = $(subst $(FontBase)-,,$(basename $(wildcard $(FontBase)-*.ufo)))
-FontStyles += $(foreach UFO,$(wildcard *.ufo),$(call ufoInstances,$(UFO)))
-FontStyles += $(foreach GLYPHS,$(wildcard *.glyphs),$(call glyphInstances,$(GLYPHS)))
+# FontStyles = $(subst $(FontBase)-,,$(basename $(wildcard $(SOURCEDIR)/$(FontBase)-*.ufo)))
+FontStyles += $(foreach UFO,$(wildcard $(SOURCEDIR)/*.ufo),$(call ufoInstances,$(UFO)))
+FontStyles += $(foreach GLYPHS,$(wildcard $(SOURCEDIR)/*.glyphs),$(call glyphInstances,$(GLYPHS)))
 
 INSTANCES = $(foreach BASE,$(FontBase),$(foreach STYLE,$(FontStyles),$(BASE)-$(STYLE)))
 

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -255,6 +255,28 @@ endif
 
 -include $(FONTSHIPDIR)/rules-$(CANONICAL).mk
 
+$(foreach FamilyName,$(FamilyNames),$(eval $(call otf_instance_template,$(FamilyName))))
+$(foreach FamilyName,$(FamilyNames),$(eval $(call ttf_instance_template,$(FamilyName))))
+
+# Final steps common to all input formats
+
+$(BUILDDIR)/%-hinted.ttf: $(BUILDDIR)/%-instance.ttf
+	$(TTFAUTOHINT) $(TTFAUTOHINTFLAGS) -n $< $@
+
+$(BUILDDIR)/%-hinted.ttf.fix: $(BUILDDIR)/%-hinted.ttf
+	$(GFTOOLS) $(GFTOOLSFLAGS) fix-hinting $<
+
+$(STATICTTFS): %.ttf: $(BUILDDIR)/%-hinted.ttf.fix $(BUILDDIR)/last-commit
+	cp $< $@
+	$(normalizeVersion)
+
+$(BUILDDIR)/%-hinted.otf: $(BUILDDIR)/%-instance.otf
+	$(PSAUTOHINT) $(PSAUTOHINTFLAGS) $< -o $@ --log $@.log
+
+$(STATICOTFS): %.otf: $(BUILDDIR)/%-hinted.otf $(BUILDDIR)/last-commit
+	cp $< $@
+	$(normalizeVersion)
+
 # Webfont compressions
 
 %.woff: %.ttf

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -84,6 +84,9 @@ GitVersion ?= $(FontVersion)-r$(shell git rev-list --count HEAD)-g$(shell git re
 isTagged :=
 endif
 
+.PHONY: default
+default: all
+
 # Look for what fonts & styles are in this repository that will need building
 FontBase = $(subst $(space),,$(FamilyName))
 
@@ -148,9 +151,6 @@ WOFF2COMPRESSFLAGS ?=
 endif
 endif
 endif
-
-.PHONY: default
-default: all
 
 .PHONY: debug
 debug:


### PR DESCRIPTION
This is a significant overhaul to how rules are organized so that they can be over-written on a per-project bases as need arises. New source formats can even be handled just by supplying templates to build instances.

Output formats can also be controlled.

Now defaults to assuming sources are in `sources/*` unless otherwise specified, per discussion in #47.

All settings are currently make variables, pending discussion in #21.