### PR TITLE
Change output compression from gz to xz

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = .version
 
 BUILT_SOURCES = .version
 
-CLEANFILES = $(bin_SCRIPTS)
+CLEANFILES = $(BUILT_SOURCES) $(bin_SCRIPTS)
 
 .version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
 	mv $@{,-prev} 2>/dev/null || touch $@-prev

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -262,7 +262,7 @@ $(DISTDIR):
 	mkdir -p $@
 
 .PHONY: dist
-dist: $(DISTDIR).zip $(DISTDIR).tar.bz2
+dist: $(DISTDIR).zip $(DISTDIR).tar.xz
 
 $(DISTDIR).tar.bz2 $(DISTDIR).tar.gz $(DISTDIR).tar.xz $(DISTDIR).zip $(DISTDIR).tar.zst: install-dist
 	bsdtar -acf $@ $(DISTDIR)

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -264,7 +264,7 @@ $(DISTDIR):
 .PHONY: dist
 dist: $(DISTDIR).zip $(DISTDIR).tar.bz2
 
-$(DISTDIR).tar.bz2 $(DISTDIR).zip: install-dist
+$(DISTDIR).tar.bz2 $(DISTDIR).tar.gz $(DISTDIR).tar.xz $(DISTDIR).zip $(DISTDIR).tar.zst: install-dist
 	bsdtar -acf $@ $(DISTDIR)
 
 dist_doc_DATA ?= $(wildcard $(foreach B,readme README,$(foreach E,md txt markdown,$(B).$(E))))


### PR DESCRIPTION
Sampling builds of Libertinus (6.8 MB of raw OTF files):

```console
.rw-r--r--  3.1M caleb 13 Aug  0:37  Libertinus-1.111.tar.bz2
.rw-r--r--  3.3M caleb 13 Aug  0:38  Libertinus-1.111.tar.gz
.rw-r--r--  1.8M caleb 13 Aug  0:37  Libertinus-1.111.tar.xz
.rw-r--r--  2.6M caleb 13 Aug  0:37  Libertinus-1.111.tar.zst
.rw-r--r--  3.3M caleb 13 Aug  0:37  Libertinus-1.111.zip
```

Since XZ compression is almost universally supported by any tar in the neighborhood, the 2× better compression just makes sense.