### PR TITLE
Handle font versioning better

### DIFF
--- a/src/rules-sfd.mk
+++ b/src/rules-sfd.mk
@@ -1,7 +1,6 @@
 needs_normalization = $(shell cmp -s $*.sfd $(BUILDDIR)/$(*F)-normalized.sfd || echo force)
 
 %.sfd: $$(needs_normalization)
-	git diff-files --quiet -- $@ || exit 1 # die if this file has uncommitted changes
 	local norm=$(BUILDDIR)/$(*F)-normalized.sfd
 	$(SFDNORMALIZE) $@ $$norm
 	cp $$norm $@

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -302,11 +302,11 @@ $(STATICOTFS): %.otf: $(BUILDDIR)/%-hinted.otf $(BUILDDIR)/last-commit
 
 # Utility stuff
 
-$(BUILDDIR)/last-commit: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)| $(BUILDDIR)
+forceiftagchange = $(shell cmp -s $@ - <<< "$(GitVersion)" || echo force)
+$(BUILDDIR)/last-commit: $$(forceiftagchange) | $(BUILDDIR)
 	git update-index --refresh --ignore-submodules ||:
 	git diff-index --quiet --cached HEAD -- $(SOURCES)
-	ts=$$(git log -n1 --pretty=format:%cI HEAD)
-	touch -d "$$ts" -- $@
+	echo $(GitVersion) > $@
 
 DISTDIR = $(PROJECT)-$(GitVersion)
 

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -81,12 +81,12 @@ FamilyName ?= $(shell $(CONTAINERIZED) || $(PYTHON) $(PYTHONFLAGS) -c 'print("$(
 
 INSTANCES ?= $(foreach FamilyName,$(FamilyNames),$(foreach STYLE,$(FontStyles),$(BASE)-$(STYLE)))
 
-GITVER = --tags --abbrev=6 --match='[0-9].[0-9][0-9][0-9]'
+GITVER = --tags --abbrev=6 --match='*[0-9].[0-9][0-9][0-9]'
 # Determine font version automatically from repository git tags
-FontVersion ?= $(shell git describe $(GITVER) 2> /dev/null | sed 's/-.*//g')
+FontVersion ?= $(shell git describe $(GITVER) 2> /dev/null | sed 's/^v//;s/-.*//g')
 ifneq ($(FontVersion),)
-FontVersionMeta ?= $(shell git describe --always --long $(GITVER) | sed 's/-[0-9]\+/\\;/;s/-g/[/')]
-GitVersion ?= $(shell git describe $(GITVER) | sed 's/-/-r/')
+FontVersionMeta ?= $(shell git describe --always --long $(GITVER) | sed 's/^v//;s/-[0-9]\+/\\;/;s/-g/[/')]
+GitVersion ?= $(shell git describe $(GITVER) | sed 's/^v//;s/-/-r/')
 isTagged := $(if $(subst $(FontVersion),,$(GitVersion)),,true)
 else
 FontVersion = 0.000


### PR DESCRIPTION
Allow prefixes like `v...`, and allow big version numbers with two digit majors like `12.000`.