### PR TITLE
Use ‘,’ instead of ‘#’ as delimiter in sed’s “s” command

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -21,7 +21,7 @@ CONTAINERIZED != test -f /.dockerenv && echo true || echo false
 
 # Initial environment setup
 FONTSHIPDIR != cd "$(shell dirname $(lastword $(MAKEFILE_LIST)))/" && pwd
-GITNAME := $(notdir $(or $(shell git remote get-url origin 2> /dev/null | sed 's#^.*/##;s#.git$$##' ||:),$(shell git worktree list | head -n1 | awk '{print $$1}')))
+GITNAME := $(notdir $(or $(shell git remote get-url origin 2> /dev/null | sed 's,^.*/,,;s,.git$$,,' ||:),$(shell git worktree list | head -n1 | awk '{print $$1}')))
 PROJECT ?= $(shell $(PYTHON) $(PYTHONFLAGS) -c 'import re; print(re.sub(r"[-_]", " ", "$(GITNAME)".title()).replace(" ", ""))')
 _PROJECTDIR != cd "$(shell dirname $(firstword $(MAKEFILE_LIST)))/" && pwd
 PROJECTDIR ?= $(_PROJECTDIR)
@@ -31,7 +31,7 @@ SOURCEDIR ?= sources
 # Some Makefile shinanigans to avoid aggressive trimming
 space := $() $()
 
-SOURCES ?= $(shell git ls-files -- '$(SOURCEDIR)/*.glyphs' '$(SOURCEDIR)/*.sfd' '$(SOURCEDIR)/*.ufo/*' | sed -e '/\.ufo/s#.ufo/.*#.ufo#' | uniq)
+SOURCES ?= $(shell git ls-files -- '$(SOURCEDIR)/*.glyphs' '$(SOURCEDIR)/*.sfd' '$(SOURCEDIR)/*.ufo/*' | sed -e '/\.ufo/s,.ufo/.*,.ufo,' | uniq)
 CANONICAL ?= $(or $(and $(filter %.glyphs,$(SOURCES)),glyphs),\
 				$(and $(filter %.sfd,$(SOURCES)),sfd),\
 				$(and $(filter %.ufo,$(SOURCES)),ufo))


### PR DESCRIPTION
The `#` is a start-of-comment character in Makefiles.  This commit changes sed to use `,` instead, as otherwise things break with

    unterminated call to function 'notdir': missing ')'.  Stop.