### PR TITLE
feat(woff): Generate webfonts from OTF if possible, fallback to TTF

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -298,11 +298,23 @@ $(STATICOTFS): %.otf: $(BUILDDIR)/%-subr.otf $(BUILDDIR)/last-commit
 
 # Webfont compressions
 
+ifeq ($(STATICOTF),true)
+
+%.woff: %.otf
+	$(SFNT2WOFF) $(SFNT2WOFFFLAGS) $<
+
+%.woff2: %.otf
+	$(WOFF2COMPRESS) $(WOFF2COMPRESSFLAGS) $<
+
+else
+
 %.woff: %.ttf
 	$(SFNT2WOFF) $(SFNT2WOFFFLAGS) $<
 
 %.woff2: %.ttf
 	$(WOFF2COMPRESS) $(WOFF2COMPRESSFLAGS) $<
+
+endif
 
 # Utility stuff
 


### PR DESCRIPTION
Not all font projects even generate TTFs, and in the cases where they generate both, the OTFs are usually a better candidate for compression to webfonts due to having more access to OpenType features.