### PR TITLE
Default to building webfonts from TTF, but fallback to OTF

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -298,7 +298,7 @@ $(STATICOTFS): %.otf: $(BUILDDIR)/%-subr.otf $(BUILDDIR)/last-commit
 
 # Webfont compressions
 
-ifeq ($(STATICOTF),true)
+ifneq ($(STATICTTF),true)
 
 %.woff: %.otf
 	$(SFNT2WOFF) $(SFNT2WOFFFLAGS) $<


### PR DESCRIPTION
This reverses the logic from #85 to default to building webfonts from TTF and only falling back to OTF if they are not available.