### PR TITLE
fix(rules): Remove the same TMP file we create, not a different one

### DIFF
--- a/src/rules-glyphs.mk
+++ b/src/rules-glyphs.mk
@@ -6,7 +6,7 @@ from glyphsLib import GSFont
 for instance in GSFont("$(SOURCE)").instances: print("_DSI_{1}{0} = {3} {2}\n_DSF_{1}{0} = $(SOURCE)".format(instance.name.replace(" ", ""), instance.familyName.replace(" ", ""), instance.name, instance.familyName))
 endef
 
-_TMP = $(shell local tmp=$$(mktemp vars-XXXXXX.mk); echo $${tmp}; {$(foreach SOURCE,$(SOURCES_GLYPHS),$(PYTHON) -c '$(makeVars)';)} >> $${tmp})
+_TMP := $(shell local tmp=$$(mktemp vars-XXXXXX.mk); echo $${tmp}; {$(foreach SOURCE,$(SOURCES_GLYPHS),$(PYTHON) -c '$(makeVars)';)} >> $${tmp})
 $(eval $(file < $(_TMP)))
 $(shell rm -f $(_TMP))
 

--- a/src/rules-ufo.mk
+++ b/src/rules-ufo.mk
@@ -11,7 +11,7 @@ for instance in designspace.instances: print("_DSI_{1}{0} = {1} {2}\n_DSF_{1}{0}
 endef
 
 ifneq ($(SOURCES_DESIGNSPACE),)
-_TMP = $(shell local tmp=$$(mktemp vars-XXXXXX.mk); echo $${tmp}; {$(foreach SOURCE,$(SOURCES_DESIGNSPACE),$(PYTHON) -c '$(makeVars)';)} >> $${tmp})
+_TMP := $(shell local tmp=$$(mktemp vars-XXXXXX.mk); echo $${tmp}; {$(foreach SOURCE,$(SOURCES_DESIGNSPACE),$(PYTHON) -c '$(makeVars)';)} >> $${tmp})
 $(eval $(file < $(_TMP)))
 $(shell rm -f $(_TMP))
 endif


### PR DESCRIPTION
With GNU Make's variable evaluation, one temporary file was getting
created during the eval, and another one created (and removed) during
the cleanup. Only allowing the variable to evaluate once should solve
that.

Closes #75.