### PR TITLE
Wrap output of make jobs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,9 @@ _fontship = $(shell sed -e "$(program_transform_name)" <<< fontship)
 
 licensedir = $(datarootdir)/licenses/$(_fontship)
 datadir = $(datarootdir)/$(_fontship)
+pkgdatadir = $(datadir)
 
+pkgdata_SCRIPTS = make-shell.zsh
 dist_doc_DATA = README.md CHANGELOG.md
 dist_man_MANS = $(_fontship).1
 dist_license_DATA = LICENSE

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -45,6 +45,21 @@ outro =
 make-header =
   Building target(s) with `make`…
 
+make-report-start =
+  Start make job for { $target }
+
+make-report-end =
+  Completed make job for { $target }
+
+make-report-fail =
+  Failed make job for { $target }
+
+make-backlog-start =
+  Dumping backlog
+
+make-backlog-end =
+  End backlog dump
+
 status-true =
   Yes
 

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -76,6 +76,9 @@ make-error-unknown-code =
   binary.  Needless to say this should not have happened. If you are not
   currently hacking on Fontship itself please report this as a bug.
 
+make-error-failed =
+  Foo
+
 status-true =
   Yes
 

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -1,34 +1,44 @@
+# Currently hard coded, see clap issue #1880
 help-description =
   The command line interface to Fontship,
   a font development toolkit and collaborative work flow.
 
+# Currently hard coded, see clap issue #1880
 help-flags-debug =
   Enable extra debug output from tooling
 
+# Currently hard coded, see clap issue #1880
 help-flags-language =
   Set language
 
+# Currently hard coded, see clap issue #1880
 help-flags-quiet =
   Discard all non-error output messages
 
+# Currently hard coded, see clap issue #1880
 help-flags-verbose =
   Enable extra verbose output from tooling
 
+# Currently hard coded, see clap issue #1880
 help-subcommand-make =
   Build specified target(s) with `make`
 
+# Currently hard coded, see clap issue #1880
 help-subcommand-make-target =
-  Target as defined in Fontship or project rules
+  Target as defined by rules in Fontship or project
 
+# Currently hard coded, see clap issue #1880
 help-subcommand-setup =
   Show status information about setup, configuration, and build state
 
+# Currently hard coded, see clap issue #1880
 help-subcommand-setup-path =
   Path to font project repository
 
 error-not-setup =
-  Project not setup for use with Fontship, run `fontship status` for details or
-  `fontship setup` to initialize.
+  This project path (if it is a project path) is not setup for use with
+  Fontship.  Please run run `fontship status` for details or `fontship setup`
+  to initialize it properly.
 
 error-invalid-language =
   Could not parse BCP47 language tag.
@@ -37,28 +47,34 @@ error-invalid-resources =
   Could not find valid BCP47 resource files.
 
 welcome =
-  Welcome to Fontship version { $version }!
+  Welcome to Fontship { $version }
 
 outro =
-  Finished Fontship run.
+  Fontship run complete
 
 make-header =
-  Building target(s) with `make`…
+  Building target(s) using `make`
 
 make-report-start =
-  Start make job for { $target }
+  Starting make job for target: { $target }
 
 make-report-end =
-  Completed make job for { $target }
+  Finished make job for target: { $target }
 
 make-report-fail =
-  Failed make job for { $target }
+  Failed make job for target: { $target }
 
 make-backlog-start =
-  Dumping backlog
+  Dumping captured output of `make`
 
 make-backlog-end =
-  End backlog dump
+  End dump
+
+make-error-unknown-code =
+  Make returned an action code Fontship doesn't have a handler for.  The most
+  likely cause is the shell helper script being out of sync with the CLI
+  binary.  Needless to say this should not have happened. If you are not
+  currently hacking on Fontship itself please report this as a bug.
 
 status-true =
   Yes
@@ -67,19 +83,19 @@ status-false =
   No
 
 status-good =
-  Everything seems to be ship shape!
+  Everything seems to be ship shape, anchors up!
 
 status-bad =
-  Not everything is seaworthy, run `fontship setup`.
+  Something isn’t seaworthy, run `fontship setup`
 
 setup-header =
-  Configuring repository for use with Fontship…
+  Configuring repository for use with Fontship
 
 status-header =
-  Project status report…
+  Scanning project status
 
 status-is-repo =
-  Are we in a Git repository?
+  Is the path a Git repository?
 
 status-is-gha =
   Are we running as a GitHub Action?
@@ -88,7 +104,7 @@ status-is-writable =
   Can we write to the project base directory?
 
 status-is-make-executable =
- Can we execute the system's `make`?
+  Is the system’s `make` executable?
 
 status-is-make-gnu =
-  Is the system's `make` GNU Make?
+  Is the system’s `make` a supported version of GNU Make?

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -2,12 +2,19 @@
 
 set +o nomatch
 
+local fifo() {
+  (
+    [[ -v FONTSHIP_FIFO && -p $FONTSHIP_FIFO ]] && exec >> $FONTSHIP_FIFO
+    echo $@
+  )
+}
+
 local pre_hook() {
-  :
+  fifo START $target
 }
 
 local post_hook() {
-  :
+  fifo END $2 $target
 }
 
 local process_recipe() {

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -18,7 +18,13 @@ local post_hook() {
 local process_recipe() {
   pre_hook $target
   {
-    ( set -e; eval $@ | sed -e "s/^/FONTSHIPLINES$target: /" )
+    (
+      set -e
+      eval $@ |
+        while read line; do
+          echo -e "FONTSHIPLINES$target$line"
+        done
+    )
   } always {
     post_hook $target $?
   }

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -8,11 +8,25 @@ local status() {
 }
 
 local pre_hook() {
-  status "FONTSHIPSTART$target"
+  status "FONTSHIPPRE$target"
 }
 
 local post_hook() {
-  status "FONTSHIPEND$2$target"
+  status "FONTSHIPPOST$2$target"
+}
+
+local report_stdout() {
+  cat - |
+    while read line; do
+      echo -e "FONTSHIPSTDOUT$target$line"
+    done
+}
+
+local report_stderr() {
+  cat - |
+    while read line; do
+      echo -e "FONTSHIPSTDERR$target$line" >&2
+    done
 }
 
 local process_recipe() {
@@ -20,10 +34,7 @@ local process_recipe() {
   {
     (
       set -e
-      eval $@ |
-        while read line; do
-          echo -e "FONTSHIPLINES$target$line"
-        done
+      eval $@ >(report_stdout) 2>(report_stdout)
     )
   } always {
     post_hook $target $?

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -34,7 +34,8 @@ local process_recipe() {
   {
     (
       set -e
-      eval $@ >(report_stdout) 2>(report_stdout)
+      exec > >(report_stdout) 2> >(report_stderr)
+      eval "$@"
     )
   } always {
     post_hook $target $?
@@ -42,7 +43,10 @@ local process_recipe() {
 }
 
 local process_shell() {
-  ( set -e; eval $@ )
+  (
+    set -e
+    eval "$@"
+  )
 }
 
 eval $1

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -1,26 +1,24 @@
 #!/usr/bin/env zsh
 
-set +o nomatch
+set -o nomatch
+set -o pipefail
 
-local fifo() {
-  (
-    [[ -v FONTSHIP_FIFO && -p $FONTSHIP_FIFO ]] && exec >> $FONTSHIP_FIFO
-    echo $@
-  )
+local status() {
+  echo -e "$@"
 }
 
 local pre_hook() {
-  fifo START $target
+  status "FONTSHIPSTART$target"
 }
 
 local post_hook() {
-  fifo END $2 $target
+  status "FONTSHIPEND$2$target"
 }
 
 local process_recipe() {
   pre_hook $target
   {
-    ( set -e; eval $@ )
+    ( set -e; eval $@ | sed -e "s/^/FONTSHIPLINES$target: /" )
   } always {
     post_hook $target $?
   }

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -1,0 +1,32 @@
+#!/usr/bin/env zsh
+
+set +o nomatch
+
+local pre_hook() {
+  :
+}
+
+local post_hook() {
+  :
+}
+
+local process_recipe() {
+  pre_hook $target
+  {
+    ( set -e; eval $@ )
+  } always {
+    post_hook $target $?
+  }
+}
+
+local process_shell() {
+  ( set -e; eval $@ )
+}
+
+eval $1
+shift
+if [[ -n $target && -v MAKELEVEL ]]; then
+  process_recipe $@
+else
+  process_shell $@
+fi

--- a/rules/fontship.mk
+++ b/rules/fontship.mk
@@ -6,12 +6,6 @@ MAKEFLAGS += --silent
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-# Run recipies in zsh, and all in one pass
-SHELL := zsh
-.SHELLFLAGS := +o nomatch -e -c
-.ONESHELL:
-.SECONDEXPANSION:
-
 # Don't drop intermediate artifacts (saves rebulid time and aids debugging)
 .SECONDARY:
 .PRECIOUS: %
@@ -27,6 +21,12 @@ _PROJECTDIR != pwd
 PROJECTDIR ?= $(_PROJECTDIR)
 PUBDIR ?= $(PROJECTDIR)/pub
 SOURCEDIR ?= sources
+
+# Run recipies in zsh wrapper, and all in one pass
+SHELL := $(FONTSHIPDIR)/make-shell.zsh
+.SHELLFLAGS = target=$@
+.ONESHELL:
+.SECONDEXPANSION:
 
 # Some Makefile shinanigans to avoid aggressive trimming
 space := $() $()

--- a/rules/fontship.mk
+++ b/rules/fontship.mk
@@ -20,7 +20,7 @@ SHELL := zsh
 CONTAINERIZED != test -f /.dockerenv && echo true || echo false
 
 # Initial environment setup
-FONTSHIPDIR != cd "$(shell dirname $(lastword $(MAKEFILE_LIST)))/" && pwd
+FONTSHIPDIR != cd "$(shell dirname $(lastword $(MAKEFILE_LIST)))/../" && pwd
 GITNAME := $(notdir $(or $(shell git remote get-url origin 2> /dev/null | sed 's,^.*/,,;s,.git$$,,' ||:),$(shell git worktree list | head -n1 | awk '{print $$1}')))
 PROJECT ?= $(shell $(PYTHON) $(PYTHONFLAGS) -c 'import re; print(re.sub(r"[-_]", " ", "$(GITNAME)".title()).replace(" ", ""))')
 _PROJECTDIR != pwd
@@ -46,7 +46,7 @@ WOFF2COMPRESS ?= woff2_compress
 
 BUILDDIR ?= .fontship
 
-include $(FONTSHIPDIR)/functions.mk
+include $(FONTSHIPDIR)/rules/functions.mk
 
 .PHONY: default
 default: all

--- a/rules/fontship.mk
+++ b/rules/fontship.mk
@@ -1,5 +1,5 @@
 # Defalut to running jobs in parallel, one for each CPU core
-MAKEFLAGS += --jobs=$(shell nproc) --output-sync=target
+MAKEFLAGS += --jobs=$(shell nproc) --output-sync=none
 # Default to not echoing commands before running
 MAKEFLAGS += --silent
 # Disable as much built in file type builds as possible

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -251,7 +251,7 @@ ifeq ($(PROJECT),Data)
 $(warning We cannot read the Project’s name inside Docker. Please manually specify it by adding PROJECT='Name' as an agument to your command invocation)
 endif
 
--include $(FONTSHIPDIR)/$(CANONICAL).mk
+-include $(FONTSHIPDIR)/rules/$(CANONICAL).mk
 
 $(foreach FamilyName,$(FamilyNames),$(eval $(call otf_instance_template,$(FamilyName))))
 $(foreach FamilyName,$(FamilyNames),$(eval $(call ttf_instance_template,$(FamilyName))))

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -58,7 +58,7 @@ GITVER = --tags --abbrev=6 --match='*[0-9].[0-9][0-9][0-9]'
 # Determine font version automatically from repository git tags
 FontVersion ?= $(shell git describe $(GITVER) 2> /dev/null | sed 's/^v//;s/-.*//g')
 ifneq ($(FontVersion),)
-FontVersionMeta ?= $(shell git describe --always --long $(GITVER) | sed 's/^v//;s/-[0-9]\+/\\;/;s/-g/[/')]
+FontVersionMeta ?= $(shell git describe --always --long $(GITVER) | sed 's/^v//;s/-[0-9]\+/;/;s/-g/[/')]
 GitVersion ?= $(shell git describe $(GITVER) | sed 's/^v//;s/-/-r/')
 isTagged := $(if $(subst $(FontVersion),,$(GitVersion)),,true)
 else
@@ -138,36 +138,36 @@ endif
 
 .PHONY: debug
 debug:
-	echo FONTSHIPDIR = $(FONTSHIPDIR)
-	echo GITNAME = $(GITNAME)
-	echo PROJECT = $(PROJECT)
-	echo PROJECTDIR = $(PROJECTDIR)
-	echo PUBDIR = $(PUBDIR)
-	echo SOURCEDIR = $(SOURCEDIR)
-	echo ----------------------------
-	echo FamilyNames = $(FamilyNames)
-	echo FontInstances = $(FontInstances)
-	echo FontVersion = $(FontVersion)
-	echo FontVersionMeta = $(FontVersionMeta)
-	echo GitVersion = $(GitVersion)
-	echo isTagged = $(isTagged)
-	echo ----------------------------
-	echo CANONICAL = $(CANONICAL)
-	echo isVariable = $(isVariable)
-	echo SOURCES = $(SOURCES)
-	echo SOURCES_SFD = $(SOURCES_SFD)
-	echo SOURCES_GLYPHS = $(SOURCES_GLYPHS)
-	echo SOURCES_UFO = $(SOURCES_UFO)
-	echo SOURCES_DESIGNSPACE = $(SOURCES_DESIGNSPACE)
-	echo INSTANCES = $(INSTANCES)
-	echo STATICOTFS = $(STATICOTFS)
-	echo STATICTTFS = $(STATICTTFS)
-	echo STATICWOFFS = $(STATICWOFFS)
-	echo STATICWOFF2S = $(STATICWOFF2S)
-	echo VARIABLEOTFS = $(VARIABLEOTFS)
-	echo VARIABLETTFS = $(VARIABLETTFS)
-	echo VARIABLEWOFFS = $(VARIABLEWOFFS)
-	echo VARIABLEWOFF2S = $(VARIABLEWOFF2S)
+	echo "FONTSHIPDIR = $(FONTSHIPDIR)"
+	echo "GITNAME = $(GITNAME)"
+	echo "PROJECT = $(PROJECT)"
+	echo "PROJECTDIR = $(PROJECTDIR)"
+	echo "PUBDIR = $(PUBDIR)"
+	echo "SOURCEDIR = $(SOURCEDIR)"
+	echo "----------------------------"
+	echo "FamilyNames = $(FamilyNames)"
+	echo "FontInstances = $(FontInstances)"
+	echo "FontVersion = $(FontVersion)"
+	echo "FontVersionMeta = $(FontVersionMeta)"
+	echo "GitVersion = $(GitVersion)"
+	echo "isTagged = $(isTagged)"
+	echo "----------------------------"
+	echo "CANONICAL = $(CANONICAL)"
+	echo "isVariable = $(isVariable)"
+	echo "SOURCES = $(SOURCES)"
+	echo "SOURCES_SFD = $(SOURCES_SFD)"
+	echo "SOURCES_GLYPHS = $(SOURCES_GLYPHS)"
+	echo "SOURCES_UFO = $(SOURCES_UFO)"
+	echo "SOURCES_DESIGNSPACE = $(SOURCES_DESIGNSPACE)"
+	echo "INSTANCES = $(INSTANCES)"
+	echo "STATICOTFS = $(STATICOTFS)"
+	echo "STATICTTFS = $(STATICTTFS)"
+	echo "STATICWOFFS = $(STATICWOFFS)"
+	echo "STATICWOFF2S = $(STATICWOFF2S)"
+	echo "VARIABLEOTFS = $(VARIABLEOTFS)"
+	echo "VARIABLETTFS = $(VARIABLETTFS)"
+	echo "VARIABLEWOFFS = $(VARIABLEWOFFS)"
+	echo "VARIABLEWOFF2S = $(VARIABLEWOFF2S)"
 
 .PHONY: _gha
 _gha: debug

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,3 +69,8 @@ pub fn header(key: &str) {
     let text = LocalText::new(key);
     eprintln!("{} {}", "┣━".cyan(), text.fmt().yellow());
 }
+
+/// Relay STDOUT/STDERR streams from internal commands
+pub fn show_line(line: String) {
+    eprintln!("{} {}", "┃ ".cyan(), line);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,3 +74,19 @@ pub fn header(key: &str) {
 pub fn show_line(line: String) {
     eprintln!("{} {}", "┃ ".cyan(), line);
 }
+
+pub fn show_start(line: &str) {
+    eprintln!("{} Start making {}", "┃ ".cyan(), line.yellow());
+}
+
+pub fn show_end(line: &str) {
+    eprintln!("{} Finish making {}", "┃ ".cyan(), line.blue());
+}
+
+pub fn show_err(line: &str) {
+    eprintln!(
+        "{} Error making {}, dumping output:",
+        "┃ ".cyan(),
+        line.red()
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,24 +69,3 @@ pub fn header(key: &str) {
     let text = LocalText::new(key);
     eprintln!("{} {}", "┣━".cyan(), text.fmt().yellow());
 }
-
-/// Relay STDOUT/STDERR streams from internal commands
-pub fn show_line(line: String) {
-    eprintln!("{} {}", "┃ ".cyan(), line);
-}
-
-pub fn show_start(line: &str) {
-    eprintln!("{} Start making {}", "┃ ".cyan(), line.yellow());
-}
-
-pub fn show_end(line: &str) {
-    eprintln!("{} Finish making {}", "┃ ".cyan(), line.blue());
-}
-
-pub fn show_err(line: &str) {
-    eprintln!(
-        "{} Error making {}, dumping output:",
-        "┃ ".cyan(),
-        line.red()
-    );
-}

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -47,6 +47,7 @@ pub fn run(target: Vec<String>) -> Result<()> {
     let buf = io::BufReader::new(out);
     let mut backlog: Vec<String> = Vec::new();
     let seps = Regex::new(r"").unwrap();
+    let mut ret: i32 = 0;
     for line in buf.lines() {
         let text: &str = &line.unwrap();
         let fields: Vec<&str> = seps.splitn(text, 4).collect();
@@ -63,9 +64,9 @@ pub fn run(target: Vec<String>) -> Result<()> {
                     "0" => {
                         report_end(fields[3]);
                     }
-                    _ => {
-                        dump_backlog(&backlog);
+                    val => {
                         report_fail(fields[3]);
+                        ret = val.parse().unwrap_or(1);
                     }
                 },
                 _ => {
@@ -76,7 +77,16 @@ pub fn run(target: Vec<String>) -> Result<()> {
             _ => backlog.push(String::from(fields[0])),
         }
     }
-    Ok(())
+    match ret {
+        0 => Ok(()),
+        _ => {
+            dump_backlog(&backlog);
+            Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                LocalText::new("make-error-failed").fmt(),
+            )))
+        }
+    }
 }
 
 fn dump_backlog(backlog: &Vec<String>) {

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -61,11 +61,11 @@ pub fn run(target: Vec<String>) -> Result<()> {
                 }
                 "POST" => match fields[2] {
                     "0" => {
-                        report_end(fields[2]);
+                        report_end(fields[3]);
                     }
                     _ => {
                         dump_backlog(&backlog);
-                        report_fail(fields[2]);
+                        report_fail(fields[3]);
                     }
                 },
                 _ => {
@@ -91,21 +91,21 @@ fn dump_backlog(backlog: &Vec<String>) {
 
 fn report_start(target: &str) {
     let text = LocalText::new("make-report-start")
-        .arg("target", target)
+        .arg("target", target.white().bold())
         .fmt();
     eprintln!("{} {}", "┠┄".cyan(), text.yellow());
 }
 
 fn report_end(target: &str) {
     let text = LocalText::new("make-report-end")
-        .arg("target", target)
+        .arg("target", target.white().bold())
         .fmt();
     eprintln!("{} {}", "┠┄".cyan(), text.green());
 }
 
 fn report_fail(target: &str) {
     let text = LocalText::new("make-report-fail")
-        .arg("target", target)
+        .arg("target", target.white().bold())
         .fmt();
     eprintln!("{} {}", "┠┄".cyan(), text.red());
 }

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -1,5 +1,6 @@
 use crate::CONFIG;
 use crate::{status, CONFIGURE_DATADIR};
+use regex::Regex;
 use std::io::prelude::*;
 use std::{error, ffi::OsString, io, result};
 use subprocess::{Exec, Redirection};
@@ -42,8 +43,28 @@ pub fn run(target: Vec<String>) -> Result<()> {
     process = process.cwd(workdir);
     let out = process.stderr(Redirection::Merge).stream_stdout()?;
     let buf = io::BufReader::new(out);
+    let mut backlog: Vec<String> = Vec::new();
+    // let re = Regex::new(r"FONTSHIP (\k+").unwrap();
+    let seps = Regex::new(r"").unwrap();
     for line in buf.lines() {
-        crate::show_line(line.unwrap());
+        let text: &str = &line.unwrap();
+        // eprintln!("foo—{}", String::from(text));
+        // backlog.push(String::from(text));
+        let fields: Vec<&str> = seps.splitn(text, 4).collect();
+        match fields[0] {
+            "FONTSHIP" => match fields[1] {
+                "START" => crate::show_start(fields[2]),
+                "LINES" => {
+                    backlog.push(String::from(fields[2]));
+                }
+                "END" => match fields[2] {
+                    "0" => crate::show_end(fields[3]),
+                    _ => crate::show_err(fields[3]),
+                },
+                _ => panic!("Fontship's make returned an unknown action code!"),
+            },
+            _ => backlog.push(String::from(fields[0])),
+        }
     }
     Ok(())
 }

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -1,7 +1,8 @@
 use crate::CONFIG;
 use crate::{status, CONFIGURE_DATADIR};
-use std::{error, ffi::OsString, result};
-use subprocess::Exec;
+use std::io::prelude::*;
+use std::{error, ffi::OsString, io, result};
+use subprocess::{Exec, Redirection};
 
 type Result<T> = result::Result<T, Box<dyn error::Error>>;
 
@@ -39,6 +40,10 @@ pub fn run(target: Vec<String>) -> Result<()> {
     let repo = status::get_repo()?;
     let workdir = repo.workdir().unwrap();
     process = process.cwd(workdir);
-    process.join()?;
+    let out = process.stderr(Redirection::Merge).stream_stdout()?;
+    let buf = io::BufReader::new(out);
+    for line in buf.lines() {
+        crate::show_line(line.unwrap());
+    }
     Ok(())
 }


### PR DESCRIPTION
Closes #99.

This is sorcery. Serious dark arts stuff: evals in subshells, z-shell multios, async subprocess stream capturing, and boiled newt toes. Well okay maybe not that last one. Seriously though the result is the most **informative and pretty** insights into to GNU Make I've ever seen, to the point where now I want to spin this off as a separate project! It's like a user friendly color UI giving you just the TL;DR; bits that [`remake --trace`](http://bashdb.sourceforge.net/remake/) could have told you if you liked `gdb`.

The short version is that the CLI is now a full blown orchestration wrapper around `make` that watches the output of parallel jobs, reports job stop and starts with a pretty interface, and only dumps more verbose content if there is a problem.