### PR TITLE
fix(cli): Don’t use backticks to unbreak zsh compdef

### DIFF
--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -21,7 +21,7 @@ help-flags-verbose =
 
 # Currently hard coded, see clap issue #1880
 help-subcommand-make =
-  Build specified target(s) with `make`
+  Build specified target(s) with ‘make’
 
 # Currently hard coded, see clap issue #1880
 help-subcommand-make-target =
@@ -37,7 +37,7 @@ help-subcommand-setup-path =
 
 error-not-setup =
   This project path (if it is a project path) is not setup for use with
-  Fontship.  Please run run `fontship status` for details or `fontship setup`
+  Fontship.  Please run run ‘fontship status’ for details or ‘fontship setup’
   to initialize it properly.
 
 error-invalid-language =
@@ -53,7 +53,7 @@ outro =
   Fontship run complete
 
 make-header =
-  Building target(s) using `make`
+  Building target(s) using ‘make’
 
 make-report-start =
   Starting make job for target: { $target }
@@ -65,7 +65,7 @@ make-report-fail =
   Failed make job for target: { $target }
 
 make-backlog-start =
-  Dumping captured output of `make`
+  Dumping captured output of ‘make’
 
 make-backlog-end =
   End dump
@@ -89,7 +89,7 @@ status-good =
   Everything seems to be ship shape, anchors up!
 
 status-bad =
-  Something isn’t seaworthy, run `fontship setup`
+  Something isn’t seaworthy, run ‘fontship setup’
 
 setup-header =
   Configuring repository for use with Fontship
@@ -107,7 +107,7 @@ status-is-writable =
   Can we write to the project base directory?
 
 status-is-make-executable =
-  Is the system’s `make` executable?
+  Is the system’s ‘make’ executable?
 
 status-is-make-gnu =
-  Is the system’s `make` a supported version of GNU Make?
+  Is the system’s ‘make’ a supported version of GNU Make?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub struct Cli {
 #[derive(Clap, Debug)]
 pub enum Subcommand {
     // FTL: help-subcommand-make
-    /// Build specified target(s) with `make`
+    /// Build specified target(s) with ‘make’
     Make {
         /// Target as defined in Fontship or project rules
         target: Vec<String>,


### PR DESCRIPTION
Currently, the generated zsh compdef contains something along the
lines of

```zsh
(( $+functions[_fontship_commands] )) ||
_fontship_commands() {
    local commands; commands=(
        "make:Build specified target(s) with `make`" \
"setup:Configure a font project repository" \
"status:Show status information about setup, configuration, and build state" \
"help:Prints this message or the help of the given subcommand(s)" \
    )
    _describe -t commands 'fontship commands' commands "$@"
}
```

I.e., it performs command substitution on ‘make’, which in the best
case fails with something along the lines of “make: *** No targets
specified and no makefile found.  Stop.” and in the worst case ends up
running ‘make’ for you.

This issue should probably be brought up to clap-rs/clap so that it is
made to use single quotes instead of double quotes and escape
everything correctly.

For now, this commit fixes the issue by using “smart quotes” instead
of backticks.