### PR TITLE
Add automatic .gitignore setup to `fontship setup`

### DIFF
--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -97,8 +97,11 @@ status-bad =
 setup-header =
   Configuring repository for use with Fontship
 
-setup-commiting-gitignore =
-  Commiting updated .gitignore file
+setup-gitignore-committing =
+  Committing updated .gitignore file
+
+setup-gitignore-fresh =
+  Existing .gitignore file is up to date
 
 status-header =
   Scanning project status

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -97,6 +97,9 @@ status-bad =
 setup-header =
   Configuring repository for use with Fontship
 
+setup-commiting-gitignore =
+  Commiting updated .gitignore file
+
 status-header =
   Scanning project status
 

--- a/rules/fontship.mk
+++ b/rules/fontship.mk
@@ -35,6 +35,8 @@ SHELL := $(FONTSHIPDIR)/make-shell.zsh
 
 # Some Makefile shinanigans to avoid aggressive trimming
 space := $() $()
+lparen := (
+rparen := )
 
 # Allow overriding executables used
 FONTMAKE ?= fontmake

--- a/rules/functions.mk
+++ b/rules/functions.mk
@@ -15,5 +15,18 @@ define normalizeVersion ?=
 	$(FONTV) $(FONTVFLAGS) write --ver=$(FontVersion) $(if $(isTagged),--rel,--dev --sha1) $@
 endef
 
+define abort_if_not_clean ?=
+	git diff-index --quiet --cached HEAD -- $@ || exit 1 # die if anything is staged
+	git diff-files --quiet -- $@ || exit 1 # die if unstaged changes
+endef
+
+define addline ?=
+	grep -Fxq "$1" $@ || echo "$1" >> $@
+endef
+
+define delline ?=
+	grep -Fxv "$1" $@ | sponge $@
+endef
+
 # Useful for testing secondary expanstions in dependencies
 ifTrue ?= $(and $1,$2)

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -240,6 +240,30 @@ variable-woff2: $$(VARIABLEWOFF2S)
 normalize: NORMALIZE_MODE = true
 normalize: $(SOURCES)
 
+.gitignore:
+	$(abort_if_not_clean)
+	$(call addline,.fontship)
+	$(call addline,$(PROJECT)-*)
+	$(call addline,!*/$(PROJECT)-*)
+	$(call addline,.DS_Store)
+	$(call addline,$(SOURCEDIR)/*$(lparen)Autosaved$(rparen).glyphs)
+	$(call addline,$(SOURCEDIR)/*_backups)
+ifneq ($(CANONICAL),glyphs)
+	$(call addline,$(SOURCEDIR)/*.glyphs)
+else
+	$(call delline,$(SOURCEDIR)/*.glyphs)
+endif
+ifneq ($(CANONICAL),sfd)
+	$(call addline,$(SOURCEDIR)/*.sfd)
+else
+	$(call delline,$(SOURCEDIR)/*.sfd)
+endif
+ifneq ($(CANONICAL),ufo)
+	$(call addline,$(SOURCEDIR)/*.ufo)
+else
+	$(call delline,$(SOURCEDIR)/*.ufo)
+endif
+
 .PHONY: check
 check: $(addsuffix -check,$(SOURCES))
 

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -240,9 +240,13 @@ variable-woff2: $$(VARIABLEWOFF2S)
 normalize: NORMALIZE_MODE = true
 normalize: $(SOURCES)
 
-.gitignore:
+.gitignore: force
 	$(abort_if_not_clean)
 	$(call addline,.fontship)
+	$(call addline,*.otf)
+	$(call addline,*.ttf)
+	$(call addline,*.woff)
+	$(call addline,*.woff2)
 	$(call addline,$(PROJECT)-*)
 	$(call addline,!*/$(PROJECT)-*)
 	$(call addline,.DS_Store)

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,7 +1,8 @@
 use crate::i18n::LocalText;
+use crate::make;
 use crate::CONFIG;
 use git2::Repository;
-use std::{error, fs, io, result};
+use std::{error, fs, io, path::Path, result};
 
 type Result<T> = result::Result<T, Box<dyn error::Error>>;
 
@@ -13,8 +14,7 @@ pub fn run() -> Result<()> {
     let metadata = fs::metadata(&path)?;
     match metadata.is_dir() {
         true => match Repository::open(path) {
-            // TODO: check that repo root is input path
-            Ok(_repo) => Ok(()),
+            Ok(repo) => regen_gitignore(repo),
             Err(_error) => Err(Box::new(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 LocalText::new("setup-error-not-git").fmt(),
@@ -24,5 +24,21 @@ pub fn run() -> Result<()> {
             io::ErrorKind::InvalidInput,
             LocalText::new("setup-error-not-dir").fmt(),
         ))),
+    }
+}
+
+fn regen_gitignore(repo: Repository) -> Result<()> {
+    let target = vec![String::from(".gitignore")];
+    make::run(target)?;
+    let path = Path::new(".gitignore");
+    let mut index = repo.index()?;
+    index.add_path(path)?;
+    let oid = index.write_tree()?;
+    match crate::commit(repo, oid, "Update .gitignore") {
+        Ok(_) => {
+            index.write()?;
+            Ok(())
+        }
+        Err(foo) => Err(Box::new(foo)),
     }
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,6 +1,7 @@
 use crate::i18n::LocalText;
 use crate::make;
 use crate::CONFIG;
+use colored::Colorize;
 use git2::Repository;
 use std::{error, fs, io, path::Path, result};
 
@@ -34,6 +35,8 @@ fn regen_gitignore(repo: Repository) -> Result<()> {
     let mut index = repo.index()?;
     index.add_path(path)?;
     let oid = index.write_tree()?;
+    let text = LocalText::new("setup-commiting-gitignore").fmt();
+    eprintln!("{} {}", "┠┄".cyan(), text);
     match crate::commit(repo, oid, "Update .gitignore") {
         Ok(_) => {
             index.write()?;


### PR DESCRIPTION
This doesn't do as much error checking as will be necessary eventually before doing more monkeying with Git internals, but I think it does enough for this particular target and we have to start somewhere.