### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           ./bootstrap.sh
           ./configure
-          echo ::set-env name=VERSION::$(./build-aux/git-version-gen .tarball-version)
-          echo ::set-env name=MAKEFLAGS::-j$(nproc) -Otarget
+          echo VERSION=$(./build-aux/git-version-gen .tarball-version) >> $GITHUB_ENV
+          echo MAKEFLAGS=-j$(nproc) -Otarget >> $GITHUB_ENV
       - name: Build
         run: |
           export PATH="$HOME/.local/bin:$PATH"
@@ -45,7 +45,7 @@ jobs:
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           make dist
-          echo ::set-env name=ISRELEASETAG::$(grep -Pqx '\d+\.\d+\.\d+' .version && echo true || echo false)
+          echo ISRELEASETAG=$(grep -Pqx '\d+\.\d+\.\d+' .version && echo true || echo false) >> $GITHUB_ENV
       - name: Upload Artifacts
         if: ${{ env.ISRELEASETAG == 'false' }}
         uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pacman-key --recv-keys 63CC496475267693 && pacman-key --lsign-key 63CC496475
 # because it saves a lot of time for local builds, but it does periodically
 # need a poke. Incrementing this when changing dependencies or just when the
 # remote Docker Hub builds die should be enough.
-ARG DOCKER_HUB_CACHE=1
+ARG DOCKER_HUB_CACHE=2
 
 # Freshen all base system packages
 RUN pacman --needed --noconfirm -Syuq && yes | pacman -Sccq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 babelfont==0.0.2
 cffsubr==0.2.7
 defcon==0.7.2
-font-v==1.0.4
+font-v==1.0.5
 fontmake==2.2.1
-fonttools[lxml,ufo,unicode,woff]==4.16.1
+fonttools[lxml,ufo,unicode,woff]==4.17.0
 gftools==0.5.0
 pcpp==1.22.0
 psautohint==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ defcon==0.7.2
 font-v==1.0.5
 fontmake==2.2.1
 fonttools[lxml,ufo,unicode,woff]==4.17.0
-gftools==0.5.0
+gftools==0.5.1
 pcpp==1.22.0
 psautohint==2.1.2
 git+git://github.com/alif-type/sfdLib.git@v1.0.6#egg=sfdLib


### PR DESCRIPTION
GFtools is [back with data files](https://github.com/googlefonts/gftools/releases/tag/v0.5.1) again (thanks again @m4rc1e).