### PR TITLE
Implement lessons learned from CaSILE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,10 +98,7 @@ dist: fontship-$(VERSION).md
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
 
-check: selfcheck
-
-.PHONY: selfcheck
-selfcheck: $(_fontship) | $(BUILT_SOURCES)
+check-local: $(_fontship) | $(BUILT_SOURCES)
 	./$< --version | grep -Ff $(firstword $|)
 
 RELTYPE ?=

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ dist_doc_DATA = README.md CHANGELOG.md
 dist_man_MANS = $(_fontship).1
 dist_license_DATA = LICENSE
 nobase_dist_data_DATA = rules/fontship.mk rules/rules.mk rules/functions.mk rules/glyphs.mk rules/sfd.mk rules/ufo.mk
-EXTRA_DIST = .version Dockerfile build-aux/cargo-updater.js build-aux/bootstrap-docker.sh
+EXTRA_DIST = .version Dockerfile build-aux/cargo-updater.js build-aux/bootstrap-docker.sh hooks/build
 
 bin_PROGRAMS = fontship
 
@@ -166,8 +166,5 @@ media_badge: media/badge.svg
 	@echo =================
 
 .PHONY: docker
-docker: Dockerfile
-	docker build \
-		--build-arg VCS_REF="$(VERSION)" \
-		--tag theleagueof/fontship:HEAD \
-		./
+docker: Dockerfile hooks/build .version
+	IMAGE_NAME=theleagueof/fontship:HEAD ./hooks/build $(VERSION)

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,8 +98,13 @@ dist: fontship-$(VERSION).md
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
 
-check-local: $(_fontship) | $(BUILT_SOURCES)
-	./$< --version | grep -Ff $(firstword $|)
+check-local: cargo-test check-local-version
+
+check-local-version: $(_fontship) | .version
+	./$< --version | grep -Ff $|
+
+cargo-test: $(_casile)
+	cargo test --locked
 
 RELTYPE ?=
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -115,9 +115,6 @@ tagrelease:
 	git diff-files --quiet && \
 	npm run release -- $(and $(RELTYPE),--release-as $(RELTYPE))
 
-.PHONY: prerelease
-prerelease: all
-
 .PHONY: release-preview
 release-preview:
 	npm run release -- --dry-run $(and $(RELTYPE),--release-as $(RELTYPE))

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,14 +21,9 @@ _fontship_assets = assets/en-US/cli.ftl
 fontship_SOURCES = Cargo.toml build.rs src/main.rs $(_fontship_libs) $(_fontship_modules) $(_fontship_assets)
 EXTRA_fontship_SOURCES = Cargo.lock
 
+
 BUILT_SOURCES = .version
-
 CLEANFILES = $(BUILT_SOURCES) $(bin_PROGRAMS)
-
-.version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
-	mv $@{,-prev} 2>/dev/null || touch $@-prev
-	( test -e .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
-	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
 
 if ENABLE_BASH_COMPLETION
 bashcompletiondir = $(BASH_COMPLETION_DIR)
@@ -89,6 +84,11 @@ $(COMPLETIONS_OUT_DIR)/_$(_fontship): $(CARGO_TARGET)
 $(CARGO_TARGET): $(fontship_SOURCES) clean-embedded-assets
 	cargo build $(CARGO_VERBOSE) $(CARGO_RELEASE_ARGS)
 
+.version: $(shell test -e .git && awk '{print ".git/" $$2}' .git/HEAD)
+	mv $@{,-prev} 2>/dev/null || touch $@-prev
+	( test -e .git && ./build-aux/git-version-gen .tarball-version || echo $(VERSION) ) > $@
+	cmp -s $@{,-prev} || autoreconf configure.ac --force -W none
+
 .PHONY: clean-embedded-assets
 clean-embedded-assets:
 	[[ ! -e .git  ]] || git clean -dxf assets
@@ -125,6 +125,10 @@ release-preview:
 .PHONY: release
 release: tagrelease
 
+fontship-%.md: CHANGELOG.md
+	sed -e '/\.\.\.v$*/,/\.\.\.v/!d' $< | \
+		sed -e '1,3d;N;$$!P;$$!D;$$d' > $@
+
 _svg_cleanup = select-all;object-to-path;vacuum-defs
 _scour_args = --quiet --set-precision=4 --remove-metadata --enable-id-stripping --strip-xml-prolog --strip-xml-space --no-line-breaks --no-renderer-workaround
 
@@ -160,10 +164,6 @@ media_badge: media/badge.svg
 	@echo =================
 	@svgo --datauri base64 --multipass --quiet -i $< -o -
 	@echo =================
-
-fontship-%.md: CHANGELOG.md
-	sed -e '/\.\.\.v$*/,/\.\.\.v/!d' $< | \
-		sed -e '1,3d;N;$$!P;$$!D;$$d' > $@
 
 .PHONY: docker
 docker: Dockerfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,9 @@ check-local-version: $(_fontship) | .version
 cargo-test: $(_casile)
 	cargo test --locked
 
+clean-local:
+	cargo clean
+
 RELTYPE ?=
 
 .PHONY: tagrelease

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -29,7 +29,7 @@ help-subcommand-make-target =
 
 # Currently hard coded, see clap issue #1880
 help-subcommand-setup =
-  Show status information about setup, configuration, and build state
+  Setup a font project for use with Fontship
 
 # Currently hard coded, see clap issue #1880
 help-subcommand-setup-path =

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DESC=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
+
+docker build \
+	--build-arg VCS_REF="${1:-$DESC}" \
+	--tag "$IMAGE_NAME" \
+	./

--- a/make-shell.zsh
+++ b/make-shell.zsh
@@ -54,7 +54,7 @@ local process_shell() {
 eval $1
 shift
 
-if [[ $1 = "+x" ]]; then
+if [[ $1 = "-x" ]]; then
   _debug=true
   shift
 fi

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -58,7 +58,7 @@ INSTANCES ?= $(foreach FamilyName,$(FamilyNames),$(foreach STYLE,$(FontInstances
 isTagged := $(and $(findstring -r0-,$(GitVersion)),true)
 
 ifeq ($(DEBUG),true)
-.SHELLFLAGS += +x
+.SHELLFLAGS += -x
 MAKEFLAGS += --no-silent
 FONTMAKEFLAGS ?= --verbose DEBUG
 FONTVFLAGS ?=

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::path;
 
 // FTL: help-description
 /// The command line interface to Fontship,
-/// A font development toolkit and collaborative work flow.
+/// a font development toolkit and collaborative work flow.
 #[derive(Clap, Debug)]
 #[clap(bin_name = "fontship")]
 #[clap(setting = AppSettings::InferSubcommands)]
@@ -42,6 +42,7 @@ pub enum Subcommand {
     // FTL: help-subcommand-make
     /// Build specified target(s) with ‘make’
     Make {
+        // FTL: help-subcommand-make-target
         /// Target as defined in Fontship or project rules
         target: Vec<String>,
     },

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -9,7 +9,7 @@ use std::{fs, io, path};
 use subprocess::{Exec, NullFile, Redirection};
 
 // FTL: help-subcommand-setup
-/// Setup Fontship for use on a new Font project
+/// Setup a font project for use with Fontship
 pub fn run() -> Result<()> {
     show_header("setup-header");
     let path = &CONF.get_string("path")?;


### PR DESCRIPTION
- chore(i18n): Fix string mismatches observed while copying to CaSILE
- refactor(cli): Stop inverting shell flag meaning
- chore(build): Add autotools hook to test Rust code
- refactor(build): Organize makefile a bit
- chore(build): Drop unused release management target
- chore(build): Add automake hook to cleanup Cargo crates
- chore(docker): Normalize Docker Hub vs. local build systems
