### PR TITLE
Fixup usage from GitHub Container Registry

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ _fontship_assets = assets/en-US/cli.ftl
 fontship_SOURCES = Cargo.toml build.rs src/main.rs $(_fontship_libs) $(_fontship_modules) $(_fontship_assets)
 EXTRA_fontship_SOURCES = Cargo.lock
 EXTRA_DIST = requirements.txt
-EXTRA_DIST += build-aux/cargo-updater.js build-aux/git-version-gen
+EXTRA_DIST += build-aux/action-updater.js build-aux/cargo-updater.js build-aux/git-version-gen
 EXTRA_DIST += Dockerfile build-aux/bootstrap-docker.sh build-aux/docker-glibc-workaround.sh hooks/build
 
 BUILT_SOURCES = .version

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ EXTRA_DIST += build-aux/action-updater.js build-aux/cargo-updater.js build-aux/g
 EXTRA_DIST += Dockerfile build-aux/bootstrap-docker.sh build-aux/docker-glibc-workaround.sh hooks/build
 
 BUILT_SOURCES = .version
-CLEANFILES = $(BUILT_SOURCES) .version-prev $(bin_PROGRAMS) fontship-$(VERSION).md
+CLEANFILES = $(BUILT_SOURCES) .version-prev $(bin_PROGRAMS)
 
 if DEBUG_RELEASE
 CARGO_RELEASE_ARGS=--all-features
@@ -159,7 +159,8 @@ release-preview:
 .PHONY: release
 release: tagrelease
 
-fontship-%.md: CHANGELOG.md
+CLEANFILES += $(PACKAGE_NAME)-$(VERSION).md
+$(PACKAGE_NAME)-%.md: CHANGELOG.md
 	$(SED) -e '/\.\.\.v$*/,/\.\.\.v/!d' $< | \
 		$(SED) -e '1,3d;N;$$!P;$$!D;$$d' > $@
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ outputs:
     description: Directory name with font family and detailed git version string
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/theleagueof/fontship:v0.8.0
   args:
     - make
     - _gha

--- a/build-aux/action-updater.js
+++ b/build-aux/action-updater.js
@@ -1,0 +1,12 @@
+const YAML = require('yaml')
+
+module.exports.readVersion = function (contents) {
+  const data = YAML.parse(contents)
+  return data.runs.image.replace(/^.*:v/, '')
+}
+
+module.exports.writeVersion = function (contents, version) {
+  const data = YAML.parse(contents)
+  data.runs.image = data.runs.image.replace(/\d+\.\d+\.\d+$/, version)
+  return YAML.stringify(data)
+}

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -e
 
-: "${ARCHTAG:=20210404.0.18927}"
+: "${ARCHTAG:=20210509.0.21942}"
 
 DESC=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
   "standard-version": {
     "bumpFiles": [
       {
+        "filename": "action.yml",
+        "updater": "build-aux/action-updater.js"
+      },
+      {
         "filename": "package.json",
         "type": "json"
       },

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/theleagueof/fontship",
   "devDependencies": {
-    "@commitlint/cli": "^12.1.1",
-    "@commitlint/config-conventional": "^12.1.1",
-    "@commitlint/prompt": "^12.1.1",
+    "@commitlint/cli": "^12.1.4",
+    "@commitlint/config-conventional": "^12.1.4",
+    "@commitlint/prompt": "^12.1.4",
     "@iarna/toml": "2.2.5",
     "commitizen": "^4.2.3",
     "conventional-changelog-cli": "^2.1.1",
     "husky": "^6.0.0",
-    "standard-version": "^9.2.0"
+    "standard-version": "^9.3.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
- feat(actions): Run GitHub Action workflows with prebuilt containers
- chore(docker): Bump Docker base image
- chore(build): Automatically bump action version on release
- chore(deps): Bump developer-only tooling
